### PR TITLE
prevent PR title and desci from being updated after first PR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.vscode
 /.build
+/.idea

--- a/actions/review.go
+++ b/actions/review.go
@@ -334,8 +334,6 @@ func createOrUpdatePR(
 		return true, errors.WithStack(err)
 	}
 	if ri.pr.Base.GetRef() != ri.baseBranch || ri.pr.GetTitle() != title || ri.pr.GetBody() != body {
-		oldTitle := ri.pr.GetTitle()
-		oldBody := ri.pr.GetBody()
 		deps.DebugLog.Println("PR", ri.pr.GetHTMLURL(), "is out of date, updating")
 		_, _, err := gitHubRepo.Client().PullRequests.Edit(
 			ctx,
@@ -344,8 +342,6 @@ func createOrUpdatePR(
 			ri.pr.GetNumber(),
 			&github.PullRequest{
 				Base:  &github.PullRequestBranch{Ref: &ri.baseBranch},
-				Title: &oldTitle,
-				Body:  &oldBody,
 			},
 		)
 		return true, errors.WithStack(err)

--- a/actions/review.go
+++ b/actions/review.go
@@ -334,6 +334,8 @@ func createOrUpdatePR(
 		return true, errors.WithStack(err)
 	}
 	if ri.pr.Base.GetRef() != ri.baseBranch || ri.pr.GetTitle() != title || ri.pr.GetBody() != body {
+		oldTitle := ri.pr.GetTitle()
+		oldBody := ri.pr.GetBody()
 		deps.DebugLog.Println("PR", ri.pr.GetHTMLURL(), "is out of date, updating")
 		_, _, err := gitHubRepo.Client().PullRequests.Edit(
 			ctx,
@@ -342,8 +344,8 @@ func createOrUpdatePR(
 			ri.pr.GetNumber(),
 			&github.PullRequest{
 				Base:  &github.PullRequestBranch{Ref: &ri.baseBranch},
-				Title: &title,
-				Body:  &body,
+				Title: &oldTitle,
+				Body:  &oldBody,
 			},
 		)
 		return true, errors.WithStack(err)


### PR DESCRIPTION
- related to [5269](https://app.clubhouse.io/bit-complete/story/5269/edited-description-gets-blown-away-by-new-revision-uploaded-from-cli)