### PR TITLE
PLZ-743 Automatically refresh auth token

### DIFF
--- a/actions/auth.go
+++ b/actions/auth.go
@@ -1,39 +1,16 @@
 package actions
 
 import (
-	"fmt"
-	"net/http"
-
-	"github.com/cli/oauth/device"
-	"github.com/pkg/errors"
+	"github.com/bitcomplete/plz-cli/client/auth"
+	"github.com/bitcomplete/plz-cli/client/deps"
 	"github.com/urfave/cli/v2"
-	"github.com/zalando/go-keyring"
 )
 
-const gitHubAppClientID = "Iv1.39b07fd4b206e0ca"
-
 func Auth(c *cli.Context) error {
-	httpClient := http.DefaultClient
-	code, err := device.RequestCode(
-		httpClient,
-		"https://github.com/login/device/code",
-		gitHubAppClientID,
-		nil,
-	)
+	deps := deps.FromContext(c.Context)
+	auth, err := auth.Prompt(deps.PlzAPIBaseURL)
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
-	fmt.Printf("Copy code: %s\n", code.UserCode)
-	fmt.Printf("then open: %s\n", code.VerificationURI)
-	accessToken, err := device.PollToken(
-		httpClient,
-		"https://github.com/login/oauth/access_token",
-		gitHubAppClientID,
-		code,
-	)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	err = keyring.Set("plz", "default", accessToken.Token)
-	return errors.WithStack(err)
+	return auth.SaveToKeyRing()
 }

--- a/actions/review.go
+++ b/actions/review.go
@@ -46,15 +46,15 @@ func Review(c *cli.Context) error {
 	ctx := c.Context
 	deps := deps.FromContext(ctx)
 
-	if deps.AuthToken == "" {
+	if deps.Auth == nil {
 		return errors.New("error loading GitHub credentials, run plz auth")
 	}
-	gitHubRepo, err := newGitHubRepo(ctx, deps.AuthToken)
+	gitHubRepo, err := newGitHubRepo(ctx, deps.Auth.Token())
 	if err != nil {
 		return err
 	}
-	graphqlClient := graphql.NewClient(deps.PlzAPIURL, &http.Client{
-		Transport: &authTransport{Token: deps.AuthToken},
+	graphqlClient := graphql.NewClient(deps.PlzAPIBaseURL+"/api/v1", &http.Client{
+		Transport: &authTransport{Token: deps.Auth.Token()},
 	})
 
 	if err := checkCleanWorktree(ctx, gitHubRepo); err != nil {

--- a/actions/switch.go
+++ b/actions/switch.go
@@ -51,10 +51,10 @@ func (r review) String() string {
 func Switch(c *cli.Context) error {
 	ctx := c.Context
 	deps := deps.FromContext(ctx)
-	if deps.AuthToken == "" {
+	if deps.Auth == nil {
 		return errors.New("error loading GitHub credentials, run plz auth")
 	}
-	gitHubRepo, err := newGitHubRepo(ctx, deps.AuthToken)
+	gitHubRepo, err := newGitHubRepo(ctx, deps.Auth.Token())
 	if err != nil {
 		return err
 	}
@@ -98,8 +98,8 @@ func Switch(c *cli.Context) error {
 		return errors.New("could not find stack")
 	}
 
-	graphqlClient := graphql.NewClient(deps.PlzAPIURL, &http.Client{
-		Transport: &authTransport{Token: deps.AuthToken},
+	graphqlClient := graphql.NewClient(deps.PlzAPIBaseURL+"/api/v1", &http.Client{
+		Transport: &authTransport{Token: deps.Auth.Token()},
 	})
 	curReview, err := loadReview(ctx, graphqlClient, reviewID)
 	if err != nil {

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -1,0 +1,169 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/cli/oauth/device"
+	"github.com/pkg/browser"
+	"github.com/pkg/errors"
+	"github.com/zalando/go-keyring"
+)
+
+type state struct {
+	Token                 string    `json:"token"`
+	ExpiresAt             time.Time `json:"expires_at"`
+	RefreshToken          string    `json:"refreshToken"`
+	RefreshTokenExpiresAt time.Time `json:"refreshTokenExpiresAt"`
+	Type                  string    `json:"type"`
+	Scope                 string    `json:"scope"`
+}
+
+type Auth struct {
+	state state
+}
+
+func (a *Auth) Token() string {
+	return a.state.Token
+}
+
+func LoadFromKeyRing(plzAPIBaseURL string) (*Auth, error) {
+	authInfoJSON, err := keyring.Get("plz", "authState")
+	if err != nil {
+		if errors.Is(err, keyring.ErrNotFound) {
+			err = nil
+		}
+		return nil, err
+	}
+	var auth Auth
+	err = json.Unmarshal([]byte(authInfoJSON), &auth.state)
+	if err != nil {
+		return nil, err
+	}
+	// Refresh the token if it's expired or nearly expired.
+	if auth.state.ExpiresAt.Before(time.Now().Add(10 * time.Minute)) {
+		err := auth.refresh(plzAPIBaseURL)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to refresh auth token")
+		}
+	}
+	return &auth, nil
+}
+
+func Prompt(plzAPIBaseURL string) (*Auth, error) {
+	httpClient := http.DefaultClient
+	gitHubAppClientID, err := fetchGitHubAppClientID(httpClient, plzAPIBaseURL)
+	if err != nil {
+		return nil, err
+	}
+	code, err := device.RequestCode(
+		httpClient,
+		"https://github.com/login/device/code",
+		gitHubAppClientID,
+		nil,
+	)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	fmt.Printf("\033[33m!\033[m First copy your one-time code: \033[1m%s\033[m\n", code.UserCode)
+	fmt.Println("Press Enter to open github.com in your browser...")
+	fmt.Scanln()
+	err = browser.OpenURL(code.VerificationURI)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	accessToken, err := device.PollToken(
+		httpClient,
+		"https://github.com/login/oauth/access_token",
+		gitHubAppClientID,
+		code,
+	)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	auth := &Auth{
+		state: state{
+			Token:        accessToken.Token,
+			RefreshToken: accessToken.RefreshToken,
+			Type:         accessToken.Type,
+			Scope:        accessToken.Scope,
+		},
+	}
+	// The device library doesn't return the expiry time, so we have to
+	// immediately refresh the token to get the expiry time.
+	err = auth.refresh(plzAPIBaseURL)
+	if err != nil {
+		return nil, err
+	}
+	return auth, nil
+}
+
+func (a *Auth) SaveToKeyRing() error {
+	stateJSON, err := json.Marshal(a.state)
+	if err != nil {
+		return err
+	}
+	err = keyring.Set("plz", "authState", string(stateJSON))
+	return err
+}
+
+func (a *Auth) refresh(plzAPIBaseURL string) error {
+	params := url.Values{"refresh_token": {a.state.RefreshToken}}
+	refreshURL := fmt.Sprintf(
+		"%s/auth/github/device/refresh?%s",
+		plzAPIBaseURL,
+		params.Encode(),
+	)
+	req, err := http.NewRequest("POST", refreshURL, nil)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	req.Header.Add("Accept", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return errors.Errorf("failed to refresh token: %s", resp.Status)
+	}
+	body := struct {
+		AccessToken           string `json:"access_token"`
+		ExpiresIn             int    `json:"expires_in"`
+		RefreshToken          string `json:"refresh_token"`
+		RefreshTokenExpiresIn int    `json:"refresh_token_expires_in"`
+		Scope                 string `json:"scope"`
+		TokenType             string `json:"token_type"`
+	}{}
+	err = json.NewDecoder(resp.Body).Decode(&body)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	a.state = state{
+		Token:                 body.AccessToken,
+		ExpiresAt:             time.Now().Add(time.Duration(body.ExpiresIn) * time.Second),
+		RefreshToken:          body.RefreshToken,
+		RefreshTokenExpiresAt: time.Now().Add(time.Duration(body.RefreshTokenExpiresIn) * time.Second),
+		Type:                  body.TokenType,
+		Scope:                 body.Scope,
+	}
+	return nil
+}
+
+func fetchGitHubAppClientID(client *http.Client, plzAPIBaseURL string) (string, error) {
+	resp, err := client.Get(plzAPIBaseURL + "/clientid")
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", errors.Errorf("failed to fetch app client ID: %s", resp.Status)
+	}
+	clientIDBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+	return string(clientIDBytes), nil
+}

--- a/deps/deps.go
+++ b/deps/deps.go
@@ -3,6 +3,8 @@ package deps
 import (
 	"context"
 	"log"
+
+	"github.com/bitcomplete/plz-cli/client/auth"
 )
 
 type depsKeyType int
@@ -10,11 +12,11 @@ type depsKeyType int
 var depsKey depsKeyType
 
 type Deps struct {
-	ErrorLog  *log.Logger
-	InfoLog   *log.Logger
-	DebugLog  *log.Logger
-	AuthToken string
-	PlzAPIURL string
+	ErrorLog *log.Logger
+	InfoLog  *log.Logger
+	DebugLog *log.Logger
+	*auth.Auth
+	PlzAPIBaseURL string
 }
 
 func ContextWithDeps(ctx context.Context, deps *Deps) context.Context {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.2
-	github.com/cli/oauth v0.8.0
+	github.com/cli/oauth v0.9.0
 	github.com/go-git/go-git/v5 v5.3.0
 	github.com/google/go-github/v32 v32.1.0
 	github.com/pkg/errors v0.9.1
@@ -31,13 +31,14 @@ require (
 	github.com/mattn/go-isatty v0.0.8 // indirect
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/russross/blackfriday/v2 v2.0.1 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/xanzy/ssh-agent v0.3.0 // indirect
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 // indirect
 	golang.org/x/net v0.0.0-20210326060303-6b1517762897 // indirect
-	golang.org/x/sys v0.0.0-20210324051608-47abb6519492 // indirect
+	golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71 // indirect
 	golang.org/x/term v0.0.0-20210503060354-a79de5458b56 // indirect
 	golang.org/x/text v0.3.3 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkY
 github.com/cli/browser v1.0.0/go.mod h1:IEWkHYbLjkhtjwwWlwTHW2lGxeS5gezEQBMLTwDHf5Q=
 github.com/cli/oauth v0.8.0 h1:YTFgPXSTvvDUFti3tR4o6q7Oll2SnQ9ztLwCAn4/IOA=
 github.com/cli/oauth v0.8.0/go.mod h1:qd/FX8ZBD6n1sVNQO3aIdRxeu5LGw9WhKnYhIIoC2A4=
+github.com/cli/oauth v0.9.0 h1:nxBC0Df4tUzMkqffAB+uZvisOwT3/N9FpkfdTDtafxc=
+github.com/cli/oauth v0.9.0/go.mod h1:qd/FX8ZBD6n1sVNQO3aIdRxeu5LGw9WhKnYhIIoC2A4=
 github.com/cli/safeexec v1.0.0/go.mod h1:Z/D4tTN8Vs5gXYHDCbaM1S/anmEDnJb1iW0+EJ5zx3Q=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
@@ -77,6 +79,8 @@ github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyex
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
+github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -129,6 +133,8 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210324051608-47abb6519492 h1:Paq34FxTluEPvVyayQqMPgHm+vTOrIifmcYxFBx9TLg=
 golang.org/x/sys v0.0.0-20210324051608-47abb6519492/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71 h1:X/2sJAybVknnUnV7AD2HdT6rm2p5BP6eH2j+igduWgk=
+golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210503060354-a79de5458b56 h1:b8jxX3zqjpqb2LklXPzKSGJhzyxCOZSz8ncv8Nv+y7w=
 golang.org/x/term v0.0.0-20210503060354-a79de5458b56/go.mod h1:tfny5GFUkzUvx4ps4ajbZsCe5lw1metzhBm9T3x7oIY=


### PR DESCRIPTION
With this change we now store a refresh token along with our access token. When
the access token is soon to expire, we will fetch a new one by exchanging our
refresh token. This uses the api.plz.review/auth/github/device/refresh endpoint
added in plz.review/review/4818.

plz-review-url: https://plz.review/review/4821