### PR TITLE
Use correct PR branch in plz review

### DIFF
--- a/actions/review.go
+++ b/actions/review.go
@@ -241,8 +241,10 @@ func getReviewInfo(
 	for _, ri := range ris {
 		if ri.reviewID == "" {
 			ri.reviewID, reservedIDs = reservedIDs[0], reservedIDs[1:]
+			ri.headBranch = fmt.Sprintf("plz.review/review/%s", ri.reviewID)
+		} else {
+			ri.headBranch = ri.pr.Head.GetRef()
 		}
-		ri.headBranch = fmt.Sprintf("plz.review/review/%s", ri.reviewID)
 		ri.baseBranch = baseBranch
 		baseBranch = ri.headBranch
 	}


### PR DESCRIPTION
We were using the hardcoded branch name as the head branch in plz review
instead of the one on the PR. Most of the time that logic is correct, but if we
want to support arbitrary branch names then we need to use the one attached to
the PR.

plz-review-url: https://plz.review/review/4913